### PR TITLE
OrderBy using expressions

### DIFF
--- a/src/main/java/com/yahoo/bullet/query/postaggregations/OrderBy.java
+++ b/src/main/java/com/yahoo/bullet/query/postaggregations/OrderBy.java
@@ -7,6 +7,7 @@ package com.yahoo.bullet.query.postaggregations;
 
 import com.yahoo.bullet.common.BulletException;
 import com.yahoo.bullet.common.Utilities;
+import com.yahoo.bullet.query.expressions.Expression;
 import com.yahoo.bullet.querying.postaggregations.OrderByStrategy;
 import com.yahoo.bullet.querying.postaggregations.PostStrategy;
 import lombok.Getter;
@@ -28,23 +29,23 @@ public class OrderBy extends PostAggregation {
     public static class SortItem implements Serializable {
         private static final long serialVersionUID = 4024279669854156179L;
 
-        private String field;
+        private Expression expression;
         private Direction direction;
 
         /**
          * Constructor that creates an {@link OrderBy} item.
          *
-         * @param field The non-null field to sort by.
+         * @param expression The non-null expression to sort by.
          * @param direction The non-null direction to sort by.
          */
-        public SortItem(String field, Direction direction) {
-            this.field = Objects.requireNonNull(field);
+        public SortItem(Expression expression, Direction direction) {
+            this.expression = Objects.requireNonNull(expression);
             this.direction = Objects.requireNonNull(direction);
         }
 
         @Override
         public String toString() {
-            return "{field: " + field + ", direction: " + direction + "}";
+            return "{expression: " + expression + ", direction: " + direction + "}";
         }
     }
 

--- a/src/main/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategy.java
+++ b/src/main/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategy.java
@@ -27,18 +27,18 @@ public class OrderByStrategy implements PostStrategy {
     private final List<Evaluator> evaluators;
     private final List<OrderBy.Direction> directions;
     private final Map<BulletRecord, LazyArray> mapping;
-    private final int numFields;
+    private final int numberOfFields;
 
-    class LazyArray {
+    private class LazyArray {
         private final BulletRecord record;
         private final TypedObject[] values;
 
-        LazyArray(BulletRecord record, int capacity) {
+        private LazyArray(BulletRecord record, int capacity) {
             this.record = record;
             this.values = new TypedObject[capacity];
         }
 
-        TypedObject get(int index) {
+        private TypedObject get(int index) {
             TypedObject value = values[index];
             if (value == null) {
                 try {
@@ -61,14 +61,14 @@ public class OrderByStrategy implements PostStrategy {
         evaluators = orderBy.getFields().stream().map(OrderBy.SortItem::getExpression).map(Expression::getEvaluator).collect(Collectors.toList());
         directions = orderBy.getFields().stream().map(OrderBy.SortItem::getDirection).collect(Collectors.toList());
         mapping = new HashMap<>();
-        numFields = orderBy.getFields().size();
+        numberOfFields = orderBy.getFields().size();
         comparator = getComparator();
     }
 
     @Override
     public Clip execute(Clip clip) {
         List<BulletRecord> records = clip.getRecords();
-        records.forEach(record -> mapping.put(record, new LazyArray(record, numFields)));
+        records.forEach(record -> mapping.put(record, new LazyArray(record, numberOfFields)));
         records.sort(comparator);
         mapping.clear();
         return clip;
@@ -79,7 +79,7 @@ public class OrderByStrategy implements PostStrategy {
             LazyArray lazyArrayA = mapping.get(a);
             LazyArray lazyArrayB = mapping.get(b);
             int c;
-            for (int i = 0; i < numFields; i++) {
+            for (int i = 0; i < numberOfFields; i++) {
                 c = directions.get(i) == OrderBy.Direction.ASC ? NULLS_FIRST.compare(lazyArrayA.get(i), lazyArrayB.get(i))
                                                                : NULLS_FIRST.compare(lazyArrayB.get(i), lazyArrayA.get(i));
                 if (c != 0) {

--- a/src/main/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategy.java
+++ b/src/main/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategy.java
@@ -5,18 +5,53 @@
  */
 package com.yahoo.bullet.querying.postaggregations;
 
+import com.yahoo.bullet.query.expressions.Expression;
 import com.yahoo.bullet.query.postaggregations.OrderBy;
+import com.yahoo.bullet.querying.evaluators.Evaluator;
 import com.yahoo.bullet.record.BulletRecord;
 import com.yahoo.bullet.result.Clip;
 import com.yahoo.bullet.typesystem.TypedObject;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class OrderByStrategy implements PostStrategy {
+    private static final Comparator<TypedObject> NULLS_FIRST = TypedObject.nullsFirst();
+
     private final Comparator<BulletRecord> comparator;
+    private final List<Evaluator> evaluators;
+    private final List<OrderBy.Direction> directions;
+    private final Map<BulletRecord, LazyList> mapping;
+    private final int numFields;
+
+    class LazyList {
+        private final BulletRecord record;
+        private final List<TypedObject> values;
+
+        LazyList(BulletRecord record, int capacity) {
+            this.record = record;
+            this.values = new ArrayList<>(capacity);
+        }
+
+        TypedObject get(int index) {
+            TypedObject value = values.get(index);
+            if (value == null) {
+                try {
+                    value = evaluators.get(index).evaluate(record);
+                } catch (Exception e) {
+                    value = TypedObject.NULL;
+                }
+                values.set(index, value);
+            }
+            return value;
+        }
+    }
 
     /**
      * Constructor that creates an OrderBy post-strategy.
@@ -24,26 +59,35 @@ public class OrderByStrategy implements PostStrategy {
      * @param orderBy The OrderBy post-aggregation to create a strategy for.
      */
     public OrderByStrategy(OrderBy orderBy) {
-        comparator = getComparator(orderBy);
+        evaluators = orderBy.getFields().stream().map(OrderBy.SortItem::getExpression).map(Expression::getEvaluator).collect(Collectors.toList());
+        directions = orderBy.getFields().stream().map(OrderBy.SortItem::getDirection).collect(Collectors.toList());
+        mapping = new HashMap<>();
+        numFields = orderBy.getFields().size();
+        comparator = getComparator();
     }
 
     @Override
     public Clip execute(Clip clip) {
         List<BulletRecord> records = clip.getRecords();
+        records.forEach(record -> mapping.put(record, new LazyList(record, numFields)));
         records.sort(comparator);
+        mapping.clear();
         return clip;
     }
 
-    private static Comparator<BulletRecord> getComparator(OrderBy orderBy) {
-        return orderBy.getFields().stream().map(OrderByStrategy::fieldComparator).reduce(Comparator::thenComparing).get();
-    }
-
-    private static Comparator<BulletRecord> fieldComparator(OrderBy.SortItem sortItem) {
+    private Comparator<BulletRecord> getComparator() {
         return (a, b) -> {
-            TypedObject typedObjectA = a.typedGet(sortItem.getField());
-            TypedObject typedObjectB = b.typedGet(sortItem.getField());
-            return sortItem.getDirection() == OrderBy.Direction.ASC ? TypedObject.nullsFirst().compare(typedObjectA, typedObjectB)
-                                                                    : TypedObject.nullsFirst().compare(typedObjectB, typedObjectA);
+            LazyList lazyListA = mapping.get(a);
+            LazyList lazyListB = mapping.get(b);
+            int c;
+            for (int i = 0; i < numFields; i++) {
+                c = directions.get(i) == OrderBy.Direction.ASC ? NULLS_FIRST.compare(lazyListA.get(i), lazyListB.get(i))
+                                                               : NULLS_FIRST.compare(lazyListB.get(i), lazyListA.get(i));
+                if (c != 0) {
+                    return c;
+                }
+            }
+            return 0;
         };
     }
 }

--- a/src/test/java/com/yahoo/bullet/query/postaggregations/OrderByTest.java
+++ b/src/test/java/com/yahoo/bullet/query/postaggregations/OrderByTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.bullet.query.postaggregations;
 
 import com.yahoo.bullet.common.BulletException;
+import com.yahoo.bullet.query.expressions.FieldExpression;
 import com.yahoo.bullet.querying.postaggregations.OrderByStrategy;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -16,12 +17,13 @@ import java.util.Collections;
 public class OrderByTest {
     @Test
     public void testOrderBy() {
-        OrderBy orderBy = new OrderBy(Arrays.asList(new OrderBy.SortItem("1", OrderBy.Direction.ASC), new OrderBy.SortItem("2", OrderBy.Direction.DESC)));
+        OrderBy orderBy = new OrderBy(Arrays.asList(new OrderBy.SortItem(new FieldExpression("1"), OrderBy.Direction.ASC),
+                                                    new OrderBy.SortItem(new FieldExpression("2"), OrderBy.Direction.DESC)));
 
         Assert.assertEquals(orderBy.getFields().size(), 2);
         Assert.assertEquals(orderBy.getType(), PostAggregationType.ORDER_BY);
         Assert.assertTrue(orderBy.getPostStrategy() instanceof OrderByStrategy);
-        Assert.assertEquals(orderBy.toString(), "{type: ORDER_BY, fields: [{field: 1, direction: ASC}, {field: 2, direction: DESC}]}");
+        Assert.assertEquals(orderBy.toString(), "{type: ORDER_BY, fields: [{expression: {field: 1, index: null, key: null, subKey: null, type: null}, direction: ASC}, {expression: {field: 2, index: null, key: null, subKey: null, type: null}, direction: DESC}]}");
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/src/test/java/com/yahoo/bullet/querying/QuerierTest.java
+++ b/src/test/java/com/yahoo/bullet/querying/QuerierTest.java
@@ -800,7 +800,7 @@ public class QuerierTest {
     @Test
     public void testOrderBy() {
         Expression filter = new UnaryExpression(new FieldExpression("a"), Operation.IS_NOT_NULL);
-        OrderBy orderBy = new OrderBy(Collections.singletonList(new OrderBy.SortItem("a", OrderBy.Direction.DESC)));
+        OrderBy orderBy = new OrderBy(Collections.singletonList(new OrderBy.SortItem(new FieldExpression("a"), OrderBy.Direction.DESC)));
         Query query = new Query(new Projection(), filter, new Raw(500), Collections.singletonList(orderBy), new Window(), null);
 
         Querier querier = make(Querier.Mode.ALL, query);

--- a/src/test/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategyTest.java
+++ b/src/test/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategyTest.java
@@ -143,7 +143,7 @@ public class OrderByStrategyTest {
     }
 
     @Test
-    public void testOrderByWithComputations1() {
+    public void testOrderByComputationWithSingleField() {
         OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem(new BinaryExpression(new FieldExpression("a"), new ValueExpression(-1), Operation.MUL), OrderBy.Direction.ASC),
                                                                     new OrderBy.SortItem(new BinaryExpression(new FieldExpression("b"), new ValueExpression(-1), Operation.MUL), OrderBy.Direction.ASC)));
         List<BulletRecord> records = new ArrayList<>();
@@ -166,7 +166,7 @@ public class OrderByStrategyTest {
     }
 
     @Test
-    public void testOrderByWithComputations2() {
+    public void testOrderByComputationWithMultipleFields() {
         OrderByStrategy orderByStrategy = makeOrderBy(Collections.singletonList(new OrderBy.SortItem(new BinaryExpression(new FieldExpression("a"), new FieldExpression("b"), Operation.ADD), OrderBy.Direction.DESC)));
         List<BulletRecord> records = new ArrayList<>();
         records.add(RecordBox.get().add("a", 5).add("b", 2).getRecord());
@@ -188,7 +188,7 @@ public class OrderByStrategyTest {
     }
 
     @Test
-    public void testOrderByWithComputationsAndSomeMissingField() {
+    public void testOrderByComputationWithMissingField() {
         OrderByStrategy orderByStrategy = makeOrderBy(Collections.singletonList(new OrderBy.SortItem(new UnaryExpression(new FieldExpression("a"), Operation.SIZE_OF), OrderBy.Direction.ASC)));
         List<BulletRecord> records = new ArrayList<>();
         records.add(RecordBox.get().add("a", "hello").getRecord());

--- a/src/test/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategyTest.java
+++ b/src/test/java/com/yahoo/bullet/querying/postaggregations/OrderByStrategyTest.java
@@ -5,6 +5,11 @@
  */
 package com.yahoo.bullet.querying.postaggregations;
 
+import com.yahoo.bullet.query.expressions.BinaryExpression;
+import com.yahoo.bullet.query.expressions.FieldExpression;
+import com.yahoo.bullet.query.expressions.Operation;
+import com.yahoo.bullet.query.expressions.UnaryExpression;
+import com.yahoo.bullet.query.expressions.ValueExpression;
 import com.yahoo.bullet.query.postaggregations.OrderBy;
 import com.yahoo.bullet.record.BulletRecord;
 import com.yahoo.bullet.result.Clip;
@@ -14,6 +19,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class OrderByStrategyTest {
@@ -23,7 +29,8 @@ public class OrderByStrategyTest {
 
     @Test
     public void testOrderByAscending() {
-        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem("a", OrderBy.Direction.ASC), new OrderBy.SortItem("b", OrderBy.Direction.ASC)));
+        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem(new FieldExpression("a"), OrderBy.Direction.ASC),
+                                                                    new OrderBy.SortItem(new FieldExpression("b"), OrderBy.Direction.ASC)));
         List<BulletRecord> records = new ArrayList<>();
         records.add(RecordBox.get().add("a", 5).add("b", 2).getRecord());
         records.add(RecordBox.get().add("a", 2).add("b", 4).getRecord());
@@ -45,7 +52,8 @@ public class OrderByStrategyTest {
 
     @Test
     public void testOrderByDescending() {
-        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem("a", OrderBy.Direction.DESC), new OrderBy.SortItem("b", OrderBy.Direction.DESC)));
+        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem(new FieldExpression("a"), OrderBy.Direction.DESC),
+                                                                    new OrderBy.SortItem(new FieldExpression("b"), OrderBy.Direction.DESC)));
         List<BulletRecord> records = new ArrayList<>();
         records.add(RecordBox.get().add("a", 5).add("b", 2).getRecord());
         records.add(RecordBox.get().add("a", 2).add("b", 4).getRecord());
@@ -67,7 +75,8 @@ public class OrderByStrategyTest {
 
     @Test
     public void testOrderByAscendingWithDifferentType() {
-        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem("a", OrderBy.Direction.ASC), new OrderBy.SortItem("b", OrderBy.Direction.ASC)));
+        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem(new FieldExpression("a"), OrderBy.Direction.ASC),
+                                                                    new OrderBy.SortItem(new FieldExpression("b"), OrderBy.Direction.ASC)));
         List<BulletRecord> records = new ArrayList<>();
         records.add(RecordBox.get().add("a", 5).add("b", 2.0).getRecord());
         records.add(RecordBox.get().add("a", 2).add("b", 4).getRecord());
@@ -89,7 +98,8 @@ public class OrderByStrategyTest {
 
     @Test
     public void testOrderByAscendingWithNonExistingField() {
-        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem("a", OrderBy.Direction.ASC), new OrderBy.SortItem("c", OrderBy.Direction.ASC)));
+        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem(new FieldExpression("a"), OrderBy.Direction.ASC),
+                                                                    new OrderBy.SortItem(new FieldExpression("c"), OrderBy.Direction.ASC)));
         List<BulletRecord> records = new ArrayList<>();
         records.add(RecordBox.get().add("a", 5).add("b", 2.0).getRecord());
         records.add(RecordBox.get().add("a", 2).add("b", 4).getRecord());
@@ -111,7 +121,8 @@ public class OrderByStrategyTest {
 
     @Test
     public void testOrderByAscendingWithSomeMissingField() {
-        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem("a", OrderBy.Direction.ASC), new OrderBy.SortItem("c", OrderBy.Direction.ASC)));
+        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem(new FieldExpression("a"), OrderBy.Direction.ASC),
+                                                                    new OrderBy.SortItem(new FieldExpression("c"), OrderBy.Direction.ASC)));
         List<BulletRecord> records = new ArrayList<>();
         records.add(RecordBox.get().add("a", 5).add("b", 2).getRecord());
         records.add(RecordBox.get().add("a", 2).add("b", 4).getRecord());
@@ -129,5 +140,70 @@ public class OrderByStrategyTest {
         Assert.assertEquals(result.getRecords().get(2).typedGet("b").getValue(), 4);
         Assert.assertEquals(result.getRecords().get(3).typedGet("a").getValue(), 5);
         Assert.assertEquals(result.getRecords().get(3).typedGet("b").getValue(), 2);
+    }
+
+    @Test
+    public void testOrderByWithComputations1() {
+        OrderByStrategy orderByStrategy = makeOrderBy(Arrays.asList(new OrderBy.SortItem(new BinaryExpression(new FieldExpression("a"), new ValueExpression(-1), Operation.MUL), OrderBy.Direction.ASC),
+                                                                    new OrderBy.SortItem(new BinaryExpression(new FieldExpression("b"), new ValueExpression(-1), Operation.MUL), OrderBy.Direction.ASC)));
+        List<BulletRecord> records = new ArrayList<>();
+        records.add(RecordBox.get().add("a", 5).add("b", 2).getRecord());
+        records.add(RecordBox.get().add("a", 2).add("b", 4).getRecord());
+        records.add(RecordBox.get().add("a", 2).add("b", 2).getRecord());
+        records.add(RecordBox.get().add("a", 1).add("b", 7).getRecord());
+        Clip clip = new Clip();
+        clip.add(records);
+        Clip result = orderByStrategy.execute(clip);
+
+        Assert.assertEquals(result.getRecords().get(0).typedGet("a").getValue(), 5);
+        Assert.assertEquals(result.getRecords().get(0).typedGet("b").getValue(), 2);
+        Assert.assertEquals(result.getRecords().get(1).typedGet("a").getValue(), 2);
+        Assert.assertEquals(result.getRecords().get(1).typedGet("b").getValue(), 4);
+        Assert.assertEquals(result.getRecords().get(2).typedGet("a").getValue(), 2);
+        Assert.assertEquals(result.getRecords().get(2).typedGet("b").getValue(), 2);
+        Assert.assertEquals(result.getRecords().get(3).typedGet("a").getValue(), 1);
+        Assert.assertEquals(result.getRecords().get(3).typedGet("b").getValue(), 7);
+    }
+
+    @Test
+    public void testOrderByWithComputations2() {
+        OrderByStrategy orderByStrategy = makeOrderBy(Collections.singletonList(new OrderBy.SortItem(new BinaryExpression(new FieldExpression("a"), new FieldExpression("b"), Operation.ADD), OrderBy.Direction.DESC)));
+        List<BulletRecord> records = new ArrayList<>();
+        records.add(RecordBox.get().add("a", 5).add("b", 2).getRecord());
+        records.add(RecordBox.get().add("a", 2).add("b", 4).getRecord());
+        records.add(RecordBox.get().add("a", 2).add("b", 2).getRecord());
+        records.add(RecordBox.get().add("a", 1).add("b", 7).getRecord());
+        Clip clip = new Clip();
+        clip.add(records);
+        Clip result = orderByStrategy.execute(clip);
+
+        Assert.assertEquals(result.getRecords().get(0).typedGet("a").getValue(), 1);
+        Assert.assertEquals(result.getRecords().get(0).typedGet("b").getValue(), 7);
+        Assert.assertEquals(result.getRecords().get(1).typedGet("a").getValue(), 5);
+        Assert.assertEquals(result.getRecords().get(1).typedGet("b").getValue(), 2);
+        Assert.assertEquals(result.getRecords().get(2).typedGet("a").getValue(), 2);
+        Assert.assertEquals(result.getRecords().get(2).typedGet("b").getValue(), 4);
+        Assert.assertEquals(result.getRecords().get(3).typedGet("a").getValue(), 2);
+        Assert.assertEquals(result.getRecords().get(3).typedGet("b").getValue(), 2);
+    }
+
+    @Test
+    public void testOrderByWithComputationsAndSomeMissingField() {
+        OrderByStrategy orderByStrategy = makeOrderBy(Collections.singletonList(new OrderBy.SortItem(new UnaryExpression(new FieldExpression("a"), Operation.SIZE_OF), OrderBy.Direction.ASC)));
+        List<BulletRecord> records = new ArrayList<>();
+        records.add(RecordBox.get().add("a", "hello").getRecord());
+        records.add(RecordBox.get().add("a", "").getRecord());
+        records.add(RecordBox.get().add("a", "foobar").getRecord());
+        records.add(RecordBox.get().getRecord());
+        records.add(RecordBox.get().add("a", "world").getRecord());
+        Clip clip = new Clip();
+        clip.add(records);
+        Clip result = orderByStrategy.execute(clip);
+
+        Assert.assertEquals(result.getRecords().get(0).typedGet("a").getValue(), null);
+        Assert.assertEquals(result.getRecords().get(1).typedGet("a").getValue(), "");
+        Assert.assertEquals(result.getRecords().get(2).typedGet("a").getValue(), "hello");
+        Assert.assertEquals(result.getRecords().get(3).typedGet("a").getValue(), "world");
+        Assert.assertEquals(result.getRecords().get(4).typedGet("a").getValue(), "foobar");
     }
 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

No tests at the moment. The approach initializes a lot of objects as final in OrderByStrategy so it can create a comparator up front. Hopefully, this is slightly better performance-wise, but I'm unsure if this will work for Spark. However, we can change that easily if necessary. Note, the LazyList class is not static so that it can access evaluators.