### PR TITLE
Fix CLA link

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -19,7 +19,7 @@ If you encounter any bugs while using this software, or want to request a new fe
 Pull requests are welcome for bug fixes. If you want to implement something new, please [request a feature first](#report-a-bug-or-request-a-feature) so we can discuss it.
 
 #### Creating a Pull Request
-Before you submit any code, we need you to agree to our [Contributor License Agreement](https://yahoocla.herokuapp.com/); this ensures we can continue to protect your contributions under an open source license well into the future.
+Before you submit any code, we need you to agree to our [Contributor License Agreement](https://yahoo.github.io/oss-guide/docs/accepting/accepting.html#contribution-licenses); this ensures we can continue to protect your contributions under an open source license well into the future.
 
 Please follow [best practices](https://github.com/trein/dev-best-practices/wiki/Git-Commit-Best-Practices) for creating git commits.
 


### PR DESCRIPTION
Link to CLA page was broken. I couldn't find exact replacement of the link, but added link to the page which is providing enough details about CLA.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
